### PR TITLE
Ensure cuTracker flushes dirty updates and add regression script

### DIFF
--- a/scripts/cutracker-regression.ts
+++ b/scripts/cutracker-regression.ts
@@ -1,0 +1,49 @@
+import assert from "assert";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cu-tracker-test-"));
+  const originalCwd = process.cwd();
+  process.chdir(tmp);
+
+  const originalWriteFile = fs.promises.writeFile;
+  (fs.promises as any).writeFile = async (...args: any[]) => {
+    await delay(50);
+    return (originalWriteFile as any).apply(fs.promises, args);
+  };
+
+  try {
+    const tracker = await import("../src/searcher/cuTracker");
+
+    tracker.resetAll();
+    await tracker.waitForIdle();
+
+    tracker.recordUsage(1);
+    const firstFlush = tracker.flushNow();
+
+    await delay(10);
+    tracker.recordUsage(1);
+
+    await firstFlush;
+    await tracker.waitForIdle();
+
+    const json = JSON.parse(fs.readFileSync(tracker.COUNTERS_FILE, "utf-8"));
+    assert.strictEqual(json.usage, 2, "usage should include both increments");
+    console.log("cuTracker regression passed");
+  } finally {
+    (fs.promises as any).writeFile = originalWriteFile;
+    process.chdir(originalCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/searcher/cuTracker.ts
+++ b/src/searcher/cuTracker.ts
@@ -1,0 +1,151 @@
+import fs from "fs";
+import path from "path";
+
+export type CuCounters = {
+  usage: number;
+  cacheHits: number;
+};
+
+const DATA_DIR = path.join(process.cwd(), "data");
+export const COUNTERS_FILE = path.join(DATA_DIR, "cu-tracker.json");
+const PERSIST_DELAY_MS = 25;
+
+function readInitial(): CuCounters {
+  if (!fs.existsSync(COUNTERS_FILE)) return { usage: 0, cacheHits: 0 };
+  try {
+    const raw = JSON.parse(fs.readFileSync(COUNTERS_FILE, "utf-8"));
+    const usage = typeof raw.usage === "number" ? raw.usage : 0;
+    const cacheHits = typeof raw.cacheHits === "number" ? raw.cacheHits : 0;
+    return { usage, cacheHits };
+  } catch {
+    return { usage: 0, cacheHits: 0 };
+  }
+}
+
+let counters: CuCounters = readInitial();
+let dirty = false;
+let pendingTimer: NodeJS.Timeout | null = null;
+let flushPromise: Promise<void> | null = null;
+
+function markDirty() {
+  dirty = true;
+}
+
+async function persistOnce(snapshot: string) {
+  await fs.promises.mkdir(DATA_DIR, { recursive: true });
+  await fs.promises.writeFile(COUNTERS_FILE, snapshot);
+}
+
+function startFlush(): Promise<void> {
+  if (flushPromise) return flushPromise;
+  if (!dirty) return Promise.resolve();
+
+  const run = (async () => {
+    try {
+      do {
+        dirty = false;
+        const snapshot = JSON.stringify(counters, null, 2);
+        await persistOnce(snapshot);
+      } while (dirty);
+    } finally {
+      flushPromise = null;
+      if (dirty) schedulePersist(true);
+    }
+  })();
+
+  flushPromise = run;
+  return run;
+}
+
+function schedulePersist(immediate = false): Promise<void> {
+  if (flushPromise) {
+    dirty = true;
+    return flushPromise;
+  }
+
+  if (!dirty) {
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+    return Promise.resolve();
+  }
+
+  if (immediate) {
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+    return startFlush();
+  }
+
+  if (pendingTimer) return Promise.resolve();
+
+  pendingTimer = setTimeout(() => {
+    pendingTimer = null;
+    if (!dirty) return;
+    startFlush();
+  }, PERSIST_DELAY_MS);
+
+  return Promise.resolve();
+}
+
+export function recordUsage(units = 1) {
+  counters.usage += units;
+  markDirty();
+  schedulePersist();
+}
+
+export function recordCacheHit(count = 1) {
+  counters.cacheHits += count;
+  markDirty();
+  schedulePersist();
+}
+
+export function resetUsage() {
+  if (counters.usage === 0) return;
+  counters.usage = 0;
+  markDirty();
+  schedulePersist(true);
+}
+
+export function resetCacheHits() {
+  if (counters.cacheHits === 0) return;
+  counters.cacheHits = 0;
+  markDirty();
+  schedulePersist(true);
+}
+
+export function resetAll() {
+  counters = { usage: 0, cacheHits: 0 };
+  markDirty();
+  schedulePersist(true);
+}
+
+export function currentCounters(): CuCounters {
+  return { ...counters };
+}
+
+export async function flushNow(): Promise<void> {
+  if (pendingTimer) {
+    clearTimeout(pendingTimer);
+    pendingTimer = null;
+  }
+  await schedulePersist(true);
+}
+
+export async function waitForIdle(): Promise<void> {
+  if (pendingTimer) {
+    await new Promise((resolve) => setTimeout(resolve, PERSIST_DELAY_MS + 5));
+    return waitForIdle();
+  }
+  if (flushPromise) {
+    try {
+      await flushPromise;
+    } finally {
+      if (dirty || pendingTimer) {
+        return waitForIdle();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a cuTracker helper that tracks usage/cache hit counters, marks updates as dirty, and ensures writes re-run immediately after an in-flight flush completes
- expose helpers for resetting counters and waiting for persistence so rapid successive updates are flushed to disk
- create a regression script that patches fs.writeFile to simulate slow I/O and verifies two quick recordUsage calls survive the double-flush scenario

## Testing
- pnpm ts-node scripts/cutracker-regression.ts
- pnpm build *(fails: existing TypeScript syntax errors in src/searcher/test-profitable.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cc44e7e51883338805d5eb8daef2b8